### PR TITLE
Add exceptional handling for invalid actions

### DIFF
--- a/main.py
+++ b/main.py
@@ -109,7 +109,11 @@ if __name__ == '__main__':
         if action == '':
             return action_meaning['NOOP']
         else:
-            return action_meaning[action]
+            try:
+                return action_meaning[action]
+            except KeyError:
+                print('Invalid key')
+                return action_meaning['NOOP']
 
     def key_press(key, mod):
         global exit


### PR DESCRIPTION
Some games in Atari have smaller action space such as Bowling-v0. Input invalid actions while playing these games will raise key error exception so I add exceptional handling to deal with these cases.